### PR TITLE
Add basic gamification

### DIFF
--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -4,10 +4,11 @@ import { Audio } from 'expo-av';
 import * as BackgroundFetch from 'expo-background-fetch';
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import * as TaskManager from 'expo-task-manager';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
 import { Animated, AppState, Easing, Modal, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import Fireworks from './Fireworks';
+import { GamificationContext } from '@/contexts/GamificationContext';
 
 const TIMER_INTERVALS = [5, 10, 15, 20, 25, 30, 45];
 const DEFAULT_MINUTES = 15;
@@ -78,6 +79,8 @@ const CircularTimer = () => {
   const intervalRef = useRef<number | null>(null);
   const [customMinutes, setCustomMinutes] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
+  const { completePomodoro } = useContext(GamificationContext);
+  const rewardGiven = useRef(false);
 
   useEffect(() => {
     activateKeepAwake();
@@ -194,6 +197,10 @@ const CircularTimer = () => {
 
   useEffect(() => {
     if (secondsLeft === 0) {
+      if (!rewardGiven.current && mode === 'focus') {
+        completePomodoro();
+        rewardGiven.current = true;
+      }
       setShowCelebration(true);
 
       // Reset and start rainbow animation (two cycles)
@@ -218,6 +225,7 @@ const CircularTimer = () => {
         clearTimeout(celebrationTimeout);
       };
     } else {
+      rewardGiven.current = false;
       setShowCelebration(false);
       gradientAnim.stopAnimation();
     }

--- a/app/Badges.tsx
+++ b/app/Badges.tsx
@@ -1,0 +1,58 @@
+import React, { useContext } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { GamificationContext } from '@/contexts/GamificationContext';
+
+const ALL_BADGES = ['First Pomodoro', 'Pomodoro Novice', 'Pomodoro Pro'];
+
+export default function Badges() {
+  const { badges } = useContext(GamificationContext);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {ALL_BADGES.map((badge) => (
+        <View key={badge} style={styles.badgeWrapper}>
+          <View
+            style={[
+              styles.badge,
+              badges.includes(badge) ? styles.unlocked : styles.locked,
+            ]}
+          >
+            <Text style={styles.badgeText}>{badge}</Text>
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    paddingVertical: 20,
+  },
+  badgeWrapper: {
+    margin: 10,
+  },
+  badge: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f4d2cd',
+  },
+  unlocked: {
+    backgroundColor: '#f26b5b',
+  },
+  locked: {
+    opacity: 0.4,
+  },
+  badgeText: {
+    color: '#fff',
+    fontSize: 12,
+    textAlign: 'center',
+    paddingHorizontal: 5,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,14 @@
 import { useFonts } from 'expo-font';
 import * as NavigationBar from 'expo-navigation-bar';
 import { StatusBar } from 'expo-status-bar';
-import { Dimensions, StyleSheet, View } from 'react-native';
+import { Dimensions, StyleSheet, View, TouchableOpacity, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState, useContext } from 'react';
 import 'react-native-reanimated';
 
 import Main from './(main)/index';
+import Badges from './Badges';
+import { GamificationProvider, GamificationContext } from '@/contexts/GamificationContext';
 
 export default function RootLayout() {
   NavigationBar.setButtonStyleAsync('dark');
@@ -13,19 +17,41 @@ export default function RootLayout() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
+  const [tab, setTab] = useState<'timer' | 'badges'>('timer');
+
   if (!loaded) {
     return null;
   }
 
   return (
-    <View style={styles.container}>
-      <Main />
-      <StatusBar
-        style="dark"
-      />
-    </View>
+    <GamificationProvider>
+      <View style={styles.container}>
+        <Header />
+        {tab === 'timer' ? <Main /> : <Badges />}
+        <View style={styles.tabBar}>
+          <TouchableOpacity style={styles.tabItem} onPress={() => setTab('timer')}>
+            <Ionicons name="timer" size={24} color={tab === 'timer' ? '#f26b5b' : '#402050'} />
+            <Text style={styles.tabLabel}>Timer</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.tabItem} onPress={() => setTab('badges')}>
+            <Ionicons name="ribbon" size={24} color={tab === 'badges' ? '#f26b5b' : '#402050'} />
+            <Text style={styles.tabLabel}>Badges</Text>
+          </TouchableOpacity>
+        </View>
+        <StatusBar style="dark" />
+      </View>
+    </GamificationProvider>
   );
 }
+
+const Header = () => {
+  const { coins, level } = useContext(GamificationContext);
+  return (
+    <View style={styles.header}>
+      <Text style={styles.headerText}>Lvl {level} • {coins} coins</Text>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -35,5 +61,30 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     width: '100%',
     height: Dimensions.get('window').height,
+  },
+  header: {
+    paddingTop: 40,
+    paddingBottom: 10,
+  },
+  headerText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#402050',
+  },
+  tabBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    width: '100%',
+    paddingVertical: 10,
+    backgroundColor: '#fdf1ef',
+    borderTopWidth: 1,
+    borderTopColor: '#e0d0cc',
+  },
+  tabItem: {
+    alignItems: 'center',
+  },
+  tabLabel: {
+    fontSize: 12,
+    color: '#402050',
   },
 });

--- a/contexts/GamificationContext.tsx
+++ b/contexts/GamificationContext.tsx
@@ -1,0 +1,75 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, { createContext, useEffect, useState } from 'react';
+
+interface GamificationState {
+  coins: number;
+  level: number;
+  badges: string[];
+  completedPomodoros: number;
+}
+
+interface GamificationContextType extends GamificationState {
+  completePomodoro: () => void;
+}
+
+const GAMIFICATION_STATE_KEY = '@gamification_state';
+
+const defaultState: GamificationState = {
+  coins: 0,
+  level: 1,
+  badges: [],
+  completedPomodoros: 0,
+};
+
+export const GamificationContext = createContext<GamificationContextType>({
+  ...defaultState,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  completePomodoro: () => {},
+});
+
+export const GamificationProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, setState] = useState<GamificationState>(defaultState);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const saved = await AsyncStorage.getItem(GAMIFICATION_STATE_KEY);
+        if (saved) {
+          setState(JSON.parse(saved));
+        }
+      } catch (e) {
+        console.error('Failed to load gamification state', e);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem(GAMIFICATION_STATE_KEY, JSON.stringify(state)).catch(console.error);
+  }, [state]);
+
+  const completePomodoro = () => {
+    const completed = state.completedPomodoros + 1;
+    const coins = state.coins + 10; // 10 coins per pomodoro
+    const level = Math.floor(completed / 10) + 1;
+    const badges = [...state.badges];
+
+    if (completed === 1 && !badges.includes('First Pomodoro')) {
+      badges.push('First Pomodoro');
+    }
+    if (completed === 5 && !badges.includes('Pomodoro Novice')) {
+      badges.push('Pomodoro Novice');
+    }
+    if (completed === 25 && !badges.includes('Pomodoro Pro')) {
+      badges.push('Pomodoro Pro');
+    }
+
+    setState({ coins, level, badges, completedPomodoros: completed });
+  };
+
+  return (
+    <GamificationContext.Provider value={{ ...state, completePomodoro }}>
+      {children}
+    </GamificationContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- add a gamification context to manage coins, levels and badges
- show a header with coins and levels
- add badge screen
- add tab bar to switch between timer and badges
- award coins on Pomodoro completion

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ef8731348320b5d25eebd36643be