### PR TITLE
Add persistent badge system

### DIFF
--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -37,7 +37,7 @@ const CircularTimer = () => {
   const intervalRef = useRef<number | null>(null);
   const [customMinutes, setCustomMinutes] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
-  const { completePomodoro } = useContext(GamificationContext);
+  const { completeSession } = useContext(GamificationContext);
   const rewardGiven = useRef(false);
 
   useEffect(() => {
@@ -59,8 +59,8 @@ const CircularTimer = () => {
 
   useEffect(() => {
     if (secondsLeft === 0) {
-      if (!rewardGiven.current && mode === 'focus') {
-        completePomodoro();
+      if (!rewardGiven.current) {
+        completeSession(mode, totalSeconds);
         rewardGiven.current = true;
       }
       setShowCelebration(true);

--- a/app/Badges.tsx
+++ b/app/Badges.tsx
@@ -1,9 +1,8 @@
 import { GamificationContext } from '@/contexts/GamificationContext';
+import { ALL_BADGES } from '@/constants/badges';
 import * as NavigationBar from 'expo-navigation-bar';
 import React, { useContext, useEffect } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
-
-const ALL_BADGES = ['First Pomodoro', 'Pomodoro Novice', 'Pomodoro Pro'];
 
 export default function Badges() {
   const { badges } = useContext(GamificationContext);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -33,7 +33,14 @@ export default function RootLayout() {
     <GamificationProvider>
       <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
         <Header />
-        {tab === 'timer' ? <Main /> : <Badges />}
+        <View style={{ flex: 1 }}>
+          <View style={{ display: tab === 'timer' ? 'flex' : 'none', flex: 1 }}>
+            <Main />
+          </View>
+          <View style={{ display: tab === 'badges' ? 'flex' : 'none', flex: 1 }}>
+            <Badges />
+          </View>
+        </View>
         <View style={styles.tabBar}>
           <TouchableOpacity style={styles.tabItem} onPress={() => setTab('timer')}>
             <Ionicons name="timer" size={24} color={tab === 'timer' ? '#f26b5b' : '#402050'} />

--- a/constants/badges.ts
+++ b/constants/badges.ts
@@ -1,0 +1,18 @@
+export type Badge =
+  | 'First pomodoro'
+  | 'Hour hero'
+  | 'Early bird'
+  | 'Night owl'
+  | 'Power hour'
+  | 'Rainy day focuser'
+  | 'AFK';
+
+export const ALL_BADGES: Badge[] = [
+  'First pomodoro',
+  'Hour hero',
+  'Early bird',
+  'Night owl',
+  'Power hour',
+  'Rainy day focuser',
+  'AFK',
+];

--- a/contexts/GamificationContext.tsx
+++ b/contexts/GamificationContext.tsx
@@ -1,14 +1,24 @@
-import React, { createContext, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ALL_BADGES, Badge } from '@/constants/badges';
+import React, { createContext, useEffect, useState } from 'react';
+
+interface SessionEntry {
+  timestamp: number;
+  mode: 'focus' | 'break';
+  duration: number;
+}
 
 interface GamificationState {
   coins: number;
   level: number;
-  badges: string[];
+  badges: Badge[];
   completedPomodoros: number;
+  totalFocusTime: number;
+  sessions: SessionEntry[];
 }
 
 interface GamificationContextType extends GamificationState {
-  completePomodoro: () => void;
+  completeSession: (mode: 'focus' | 'break', duration: number) => void;
 }
 
 const defaultState: GamificationState = {
@@ -16,37 +26,115 @@ const defaultState: GamificationState = {
   level: 1,
   badges: [],
   completedPomodoros: 0,
+  totalFocusTime: 0,
+  sessions: [],
 };
 
 export const GamificationContext = createContext<GamificationContextType>({
   ...defaultState,
-  completePomodoro: () => {},
+  completeSession: () => {},
 });
+
+const STORAGE_KEY = 'gamificationState';
+
+const isRainy = async (): Promise<boolean> => {
+  // Placeholder for weather check. Integrate with weather API here.
+  return false;
+};
 
 export const GamificationProvider = ({ children }: { children: React.ReactNode }) => {
   const [state, setState] = useState<GamificationState>(defaultState);
 
-  const completePomodoro = () => {
-    const completed = state.completedPomodoros + 1;
-    const coins = state.coins + 10; // 10 coins per pomodoro
-    const level = Math.floor(completed / 10) + 1;
-    const badges = [...state.badges];
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await AsyncStorage.getItem(STORAGE_KEY);
+        if (data) {
+          setState(JSON.parse(data));
+        }
+      } catch (e) {
+        console.log('Failed to load gamification state', e);
+      }
+    })();
+  }, []);
 
-    if (completed === 1 && !badges.includes('First Pomodoro')) {
-      badges.push('First Pomodoro');
-    }
-    if (completed === 5 && !badges.includes('Pomodoro Novice')) {
-      badges.push('Pomodoro Novice');
-    }
-    if (completed === 25 && !badges.includes('Pomodoro Pro')) {
-      badges.push('Pomodoro Pro');
+  useEffect(() => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state)).catch((e) =>
+      console.log('Failed to save gamification state', e)
+    );
+  }, [state]);
+
+  const completeSession = async (mode: 'focus' | 'break', duration: number) => {
+    const now = new Date();
+    const sessions = [...state.sessions, { timestamp: now.getTime(), mode, duration }];
+
+    let { coins, completedPomodoros, totalFocusTime, badges } = state;
+
+    if (mode === 'focus') {
+      completedPomodoros += 1;
+      totalFocusTime += duration;
+      coins += 10; // 10 coins per focus session
     }
 
-    setState({ coins, level, badges, completedPomodoros: completed });
+    // Badge conditions
+    if (completedPomodoros >= 1 && !badges.includes('First pomodoro')) {
+      badges = [...badges, 'First pomodoro'];
+    }
+
+    if (totalFocusTime >= 3600 && !badges.includes('Hour hero')) {
+      badges = [...badges, 'Hour hero'];
+    }
+
+    const hour = now.getHours();
+    if (mode === 'focus' && hour < 10 && !badges.includes('Early bird')) {
+      badges = [...badges, 'Early bird'];
+    }
+
+    if (mode === 'focus' && hour >= 22 && !badges.includes('Night owl')) {
+      badges = [...badges, 'Night owl'];
+    }
+
+    if (mode === 'break' && duration >= 900 && !badges.includes('AFK')) {
+      badges = [...badges, 'AFK'];
+    }
+
+    if (!badges.includes('Power hour')) {
+      const todayHours = sessions
+        .filter(
+          (s) =>
+            s.mode === 'focus' && new Date(s.timestamp).toDateString() === now.toDateString()
+        )
+        .map((s) => new Date(s.timestamp).getHours());
+      const required = [9, 10, 11, 12, 13, 14, 15, 16];
+      if (required.every((h) => todayHours.includes(h))) {
+        badges = [...badges, 'Power hour'];
+      }
+    }
+
+    if (mode === 'focus' && !badges.includes('Rainy day focuser')) {
+      try {
+        if (await isRainy()) {
+          badges = [...badges, 'Rainy day focuser'];
+        }
+      } catch (e) {
+        console.log('Weather check failed', e);
+      }
+    }
+
+    const level = Math.floor(completedPomodoros / 10) + 1;
+
+    setState({
+      coins,
+      level,
+      badges,
+      completedPomodoros,
+      totalFocusTime,
+      sessions,
+    });
   };
 
   return (
-    <GamificationContext.Provider value={{ ...state, completePomodoro }}>
+    <GamificationContext.Provider value={{ ...state, completeSession }}>
       {children}
     </GamificationContext.Provider>
   );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "expo-av": "~15.1.6",
-    "expo-updates": "~0.28.14"
+    "expo-updates": "~0.28.14",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- store badges for pomodoro missions in AsyncStorage
- keep timer running when navigating to badges page
- show all badges from a central constants file
- update timer to report finished sessions to context
- add AsyncStorage dependency

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_6856f9c12a2c8320bec64231f998e2ae