### PR TITLE
Add badge details, history tab, and notifications

### DIFF
--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -60,7 +60,7 @@ const CircularTimer = () => {
   useEffect(() => {
     if (secondsLeft === 0) {
       if (!rewardGiven.current) {
-        completeSession(mode, totalSeconds);
+        completeSession(mode, totalSeconds, true);
         rewardGiven.current = true;
       }
       setShowCelebration(true);
@@ -137,6 +137,10 @@ const CircularTimer = () => {
   };
 
   const resetTimer = () => {
+    if (secondsLeft !== totalSeconds) {
+      const elapsed = totalSeconds - secondsLeft;
+      completeSession(mode, elapsed, false);
+    }
     setSecondsLeft(totalSeconds);
     setIsRunning(false);
     setBackgroundColor(DEFAULT_BACKGROUND);

--- a/app/Badges.tsx
+++ b/app/Badges.tsx
@@ -1,30 +1,68 @@
 import { GamificationContext } from '@/contexts/GamificationContext';
-import { ALL_BADGES } from '@/constants/badges';
+import { ALL_BADGES, BADGE_DETAILS, Badge } from '@/constants/badges';
 import * as NavigationBar from 'expo-navigation-bar';
-import React, { useContext, useEffect } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-export default function Badges() {
-  const { badges } = useContext(GamificationContext);
+export default function Badges({ highlightBadge, clearHighlight }: { highlightBadge?: Badge | null; clearHighlight?: () => void; }) {
+  const { badges, badgeDates } = useContext(GamificationContext);
+  const [selected, setSelected] = useState<Badge | null>(null);
+  const [highlight, setHighlight] = useState<Badge | null>(null);
   useEffect(() => {
     NavigationBar.setButtonStyleAsync('dark');
     NavigationBar.setBackgroundColorAsync('#000');
   }, []);
 
+  useEffect(() => {
+    if (highlightBadge) {
+      setHighlight(highlightBadge);
+      const t = setTimeout(() => {
+        setHighlight(null);
+        clearHighlight && clearHighlight();
+      }, 3000);
+      return () => clearTimeout(t);
+    }
+  }, [highlightBadge]);
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       {ALL_BADGES.map((badge) => (
-        <View key={badge} style={styles.badgeWrapper}>
+        <TouchableOpacity key={badge} style={styles.badgeWrapper} onPress={() => setSelected(badge)}>
           <View
             style={[
               styles.badge,
               badges.includes(badge) ? styles.unlocked : styles.locked,
+              highlight === badge && styles.highlight,
             ]}
           >
             <Text style={styles.badgeText}>{badge}</Text>
           </View>
-        </View>
+        </TouchableOpacity>
       ))}
+      <Modal transparent visible={selected !== null} animationType="fade">
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalContent}>
+            {selected && (
+              <>
+                <Text style={styles.modalTitle}>{selected}</Text>
+                {badges.includes(selected) ? (
+                  <Text style={styles.earnedText}>
+                    Earned on {badgeDates[selected] ? new Date(badgeDates[selected]!).toLocaleDateString() : ''}
+                  </Text>
+                ) : (
+                  <Text style={styles.earnedText}>Not earned yet</Text>
+                )}
+                {BADGE_DETAILS[selected].map((d, i) => (
+                  <Text key={i} style={styles.detailItem}>• {d}</Text>
+                ))}
+                <TouchableOpacity onPress={() => setSelected(null)} style={styles.closeModal}>
+                  <Text style={styles.closeText}>Close</Text>
+                </TouchableOpacity>
+              </>
+            )}
+          </View>
+        </View>
+      </Modal>
     </ScrollView>
   );
 }
@@ -47,6 +85,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#f4d2cd',
   },
+  highlight: {
+    borderWidth: 3,
+    borderColor: '#ffd700',
+  },
   unlocked: {
     backgroundColor: '#f26b5b',
   },
@@ -58,5 +100,43 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textAlign: 'center',
     paddingHorizontal: 5,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    width: '80%',
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 20,
+    alignItems: 'center',
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 10,
+    color: '#402050',
+    textAlign: 'center',
+  },
+  earnedText: {
+    marginBottom: 10,
+    color: '#402050',
+  },
+  detailItem: {
+    color: '#402050',
+    alignSelf: 'flex-start',
+  },
+  closeModal: {
+    marginTop: 20,
+    padding: 10,
+    backgroundColor: '#f26b5b',
+    borderRadius: 8,
+  },
+  closeText: {
+    color: '#fff',
+    fontWeight: '600',
   },
 });

--- a/app/History.tsx
+++ b/app/History.tsx
@@ -1,0 +1,66 @@
+import { GamificationContext } from '@/contexts/GamificationContext';
+import { Ionicons } from '@expo/vector-icons';
+import * as NavigationBar from 'expo-navigation-bar';
+import React, { useContext, useEffect } from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+
+export default function History() {
+  const { sessions } = useContext(GamificationContext);
+
+  useEffect(() => {
+    NavigationBar.setButtonStyleAsync('dark');
+    NavigationBar.setBackgroundColorAsync('#000');
+  }, []);
+
+  const renderItem = ({ item }: any) => {
+    const date = new Date(item.timestamp);
+    const time = date.toLocaleString();
+    return (
+      <View style={styles.item}>
+        <Ionicons
+          name={item.mode === 'focus' ? 'timer' : 'cafe'}
+          color={item.completed ? '#4caf50' : '#f26b5b'}
+          size={20}
+          style={{ marginRight: 8 }}
+        />
+        <View style={{ flex: 1 }}>
+          <Text style={styles.itemText}>{time}</Text>
+          <Text style={styles.subText}>
+            {item.mode} • {Math.round(item.duration / 60)}m •{' '}
+            {item.completed ? 'completed' : 'stopped'}
+          </Text>
+        </View>
+      </View>
+    );
+  };
+
+  return (
+    <FlatList
+      data={[...sessions].reverse()}
+      keyExtractor={(item) => String(item.timestamp)}
+      renderItem={renderItem}
+      contentContainerStyle={styles.container}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ddd',
+  },
+  itemText: {
+    fontSize: 16,
+    color: '#402050',
+  },
+  subText: {
+    fontSize: 12,
+    color: '#666',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,15 +8,15 @@ import 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { GamificationContext, GamificationProvider } from '@/contexts/GamificationContext';
+import { Badge } from '@/constants/badges';
 import Main from './(main)/index';
 import Badges from './Badges';
+import History from './History';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
-
-  const [tab, setTab] = useState<'timer' | 'badges'>('timer');
   const insets = useSafeAreaInsets();
 
   // Set Android navigation bar buttons to dark
@@ -31,31 +31,60 @@ export default function RootLayout() {
 
   return (
     <GamificationProvider>
-      <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
-        <Header />
-        <View style={{ flex: 1 }}>
-          <View style={{ display: tab === 'timer' ? 'flex' : 'none', flex: 1 }}>
-            <Main />
-          </View>
-          <View style={{ display: tab === 'badges' ? 'flex' : 'none', flex: 1 }}>
-            <Badges />
-          </View>
-        </View>
-        <View style={styles.tabBar}>
-          <TouchableOpacity style={styles.tabItem} onPress={() => setTab('timer')}>
-            <Ionicons name="timer" size={24} color={tab === 'timer' ? '#f26b5b' : '#402050'} />
-            <Text style={styles.tabLabel}>Timer</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.tabItem} onPress={() => setTab('badges')}>
-            <Ionicons name="ribbon" size={24} color={tab === 'badges' ? '#f26b5b' : '#402050'} />
-            <Text style={styles.tabLabel}>Badges</Text>
-          </TouchableOpacity>
-        </View>
-        <StatusBar style="dark" />
-      </View>
+      <InnerContent paddingTop={insets.top} paddingBottom={insets.bottom} />
     </GamificationProvider>
   );
 }
+
+const InnerContent = ({ paddingTop, paddingBottom }: { paddingTop: number; paddingBottom: number }) => {
+  const [tab, setTab] = useState<'timer' | 'badges' | 'history'>('timer');
+  const [highlightBadge, setHighlightBadge] = useState<Badge | null>(null);
+  const { recentBadge, clearRecentBadge } = useContext(GamificationContext);
+
+  return (
+    <View style={[styles.container, { paddingTop, paddingBottom }]}>
+      <Header />
+      {recentBadge && (
+        <TouchableOpacity
+          style={styles.notification}
+          onPress={() => {
+            setTab('badges');
+            setHighlightBadge(recentBadge);
+            clearRecentBadge();
+          }}
+        >
+          <Text style={styles.notificationText}>You earned a badge! {recentBadge}</Text>
+        </TouchableOpacity>
+      )}
+      <View style={{ flex: 1 }}>
+        <View style={{ display: tab === 'timer' ? 'flex' : 'none', flex: 1 }}>
+          <Main />
+        </View>
+        <View style={{ display: tab === 'badges' ? 'flex' : 'none', flex: 1 }}>
+          <Badges highlightBadge={highlightBadge} clearHighlight={() => setHighlightBadge(null)} />
+        </View>
+        <View style={{ display: tab === 'history' ? 'flex' : 'none', flex: 1 }}>
+          <History />
+        </View>
+      </View>
+      <View style={styles.tabBar}>
+        <TouchableOpacity style={styles.tabItem} onPress={() => setTab('timer')}>
+          <Ionicons name="timer" size={24} color={tab === 'timer' ? '#f26b5b' : '#402050'} />
+          <Text style={styles.tabLabel}>Timer</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.tabItem} onPress={() => setTab('badges')}>
+          <Ionicons name="ribbon" size={24} color={tab === 'badges' ? '#f26b5b' : '#402050'} />
+          <Text style={styles.tabLabel}>Badges</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.tabItem} onPress={() => setTab('history')}>
+          <Ionicons name="book" size={24} color={tab === 'history' ? '#f26b5b' : '#402050'} />
+          <Text style={styles.tabLabel}>History</Text>
+        </TouchableOpacity>
+      </View>
+      <StatusBar style="dark" />
+    </View>
+  );
+};
 
 const Header = () => {
   const { coins, level } = useContext(GamificationContext);
@@ -99,5 +128,14 @@ const styles = StyleSheet.create({
   tabLabel: {
     fontSize: 12,
     color: '#402050',
+  },
+  notification: {
+    backgroundColor: '#333',
+    padding: 10,
+    width: '100%',
+    alignItems: 'center',
+  },
+  notificationText: {
+    color: '#fff',
   },
 });

--- a/constants/badges.ts
+++ b/constants/badges.ts
@@ -16,3 +16,15 @@ export const ALL_BADGES: Badge[] = [
   'Rainy day focuser',
   'AFK',
 ];
+
+export const BADGE_DETAILS: Record<Badge, string[]> = {
+  'First pomodoro': ['Finish your first focus session.'],
+  'Hour hero': ['Accumulate one hour of total focus time.'],
+  'Early bird': ['Complete a focus session before 10:00 AM.'],
+  'Night owl': ['Complete a focus session after 10:00 PM.'],
+  'Power hour': [
+    'Complete focus sessions during every hour from 9 AM to 4 PM on the same day.',
+  ],
+  'Rainy day focuser': ['Complete a focus session while it is raining.'],
+  AFK: ['Take a break that lasts at least 15 minutes.'],
+};

--- a/contexts/GamificationContext.tsx
+++ b/contexts/GamificationContext.tsx
@@ -6,33 +6,47 @@ interface SessionEntry {
   timestamp: number;
   mode: 'focus' | 'break';
   duration: number;
+  completed: boolean;
 }
 
 interface GamificationState {
   coins: number;
   level: number;
   badges: Badge[];
+  badgeDates: Record<Badge, number | null>;
   completedPomodoros: number;
   totalFocusTime: number;
   sessions: SessionEntry[];
+  recentBadge: Badge | null;
 }
 
 interface GamificationContextType extends GamificationState {
-  completeSession: (mode: 'focus' | 'break', duration: number) => void;
+  completeSession: (
+    mode: 'focus' | 'break',
+    duration: number,
+    completed: boolean
+  ) => void;
+  clearRecentBadge: () => void;
 }
 
 const defaultState: GamificationState = {
   coins: 0,
   level: 1,
   badges: [],
+  badgeDates: ALL_BADGES.reduce<Record<Badge, number | null>>(
+    (acc, b) => ({ ...acc, [b]: null }),
+    {}
+  ),
   completedPomodoros: 0,
   totalFocusTime: 0,
   sessions: [],
+  recentBadge: null,
 };
 
 export const GamificationContext = createContext<GamificationContextType>({
   ...defaultState,
   completeSession: () => {},
+  clearRecentBadge: () => {},
 });
 
 const STORAGE_KEY = 'gamificationState';
@@ -64,13 +78,22 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     );
   }, [state]);
 
-  const completeSession = async (mode: 'focus' | 'break', duration: number) => {
+  const completeSession = async (
+    mode: 'focus' | 'break',
+    duration: number,
+    completed: boolean
+  ) => {
     const now = new Date();
-    const sessions = [...state.sessions, { timestamp: now.getTime(), mode, duration }];
+    const sessions = [
+      ...state.sessions,
+      { timestamp: now.getTime(), mode, duration, completed },
+    ];
 
-    let { coins, completedPomodoros, totalFocusTime, badges } = state;
+    let { coins, completedPomodoros, totalFocusTime, badges, badgeDates } = state;
 
-    if (mode === 'focus') {
+    let recentBadge: Badge | null = null;
+
+    if (completed && mode === 'focus') {
       completedPomodoros += 1;
       totalFocusTime += duration;
       coins += 10; // 10 coins per focus session
@@ -79,26 +102,36 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     // Badge conditions
     if (completedPomodoros >= 1 && !badges.includes('First pomodoro')) {
       badges = [...badges, 'First pomodoro'];
+      badgeDates['First pomodoro'] = now.getTime();
+      recentBadge = 'First pomodoro';
     }
 
     if (totalFocusTime >= 3600 && !badges.includes('Hour hero')) {
       badges = [...badges, 'Hour hero'];
+      badgeDates['Hour hero'] = now.getTime();
+      recentBadge = 'Hour hero';
     }
 
     const hour = now.getHours();
-    if (mode === 'focus' && hour < 10 && !badges.includes('Early bird')) {
+    if (completed && mode === 'focus' && hour < 10 && !badges.includes('Early bird')) {
       badges = [...badges, 'Early bird'];
+      badgeDates['Early bird'] = now.getTime();
+      recentBadge = 'Early bird';
     }
 
-    if (mode === 'focus' && hour >= 22 && !badges.includes('Night owl')) {
+    if (completed && mode === 'focus' && hour >= 22 && !badges.includes('Night owl')) {
       badges = [...badges, 'Night owl'];
+      badgeDates['Night owl'] = now.getTime();
+      recentBadge = 'Night owl';
     }
 
-    if (mode === 'break' && duration >= 900 && !badges.includes('AFK')) {
+    if (completed && mode === 'break' && duration >= 900 && !badges.includes('AFK')) {
       badges = [...badges, 'AFK'];
+      badgeDates['AFK'] = now.getTime();
+      recentBadge = 'AFK';
     }
 
-    if (!badges.includes('Power hour')) {
+    if (completed && !badges.includes('Power hour')) {
       const todayHours = sessions
         .filter(
           (s) =>
@@ -108,13 +141,17 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       const required = [9, 10, 11, 12, 13, 14, 15, 16];
       if (required.every((h) => todayHours.includes(h))) {
         badges = [...badges, 'Power hour'];
+        badgeDates['Power hour'] = now.getTime();
+        recentBadge = 'Power hour';
       }
     }
 
-    if (mode === 'focus' && !badges.includes('Rainy day focuser')) {
+    if (completed && mode === 'focus' && !badges.includes('Rainy day focuser')) {
       try {
         if (await isRainy()) {
           badges = [...badges, 'Rainy day focuser'];
+          badgeDates['Rainy day focuser'] = now.getTime();
+          recentBadge = 'Rainy day focuser';
         }
       } catch (e) {
         console.log('Weather check failed', e);
@@ -127,14 +164,20 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       coins,
       level,
       badges,
+      badgeDates,
       completedPomodoros,
       totalFocusTime,
       sessions,
+      recentBadge,
     });
   };
 
+  const clearRecentBadge = () => {
+    setState((prev) => ({ ...prev, recentBadge: null }));
+  };
+
   return (
-    <GamificationContext.Provider value={{ ...state, completeSession }}>
+    <GamificationContext.Provider value={{ ...state, completeSession, clearRecentBadge }}>
       {children}
     </GamificationContext.Provider>
   );


### PR DESCRIPTION
## Summary
- show descriptions for badges
- track when badges are earned
- display badge details in modal
- add in‑app notification for new badges
- record session history and add History page
- update layout for new tab

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_6856fcdc2ee48320b443bffbb30db021