### PR TITLE
Add badge missions, history log and notifications

### DIFF
--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -37,7 +37,8 @@ const CircularTimer = () => {
   const intervalRef = useRef<number | null>(null);
   const [customMinutes, setCustomMinutes] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
-  const { completeSession } = useContext(GamificationContext);
+  const { completeSession, logSession } = useContext(GamificationContext);
+  const [startTime, setStartTime] = useState<number | null>(null);
   const rewardGiven = useRef(false);
 
   useEffect(() => {
@@ -64,6 +65,7 @@ const CircularTimer = () => {
         rewardGiven.current = true;
       }
       setShowCelebration(true);
+      setStartTime(null);
 
       // Reset and start rainbow animation (two cycles)
       gradientAnim.setValue(0);
@@ -137,16 +139,21 @@ const CircularTimer = () => {
   };
 
   const resetTimer = () => {
+    if (startTime && secondsLeft !== totalSeconds && secondsLeft > 0) {
+      logSession(mode, totalSeconds, false);
+    }
     setSecondsLeft(totalSeconds);
     setIsRunning(false);
     setBackgroundColor(DEFAULT_BACKGROUND);
     animatedValue.setValue(0);
+    setStartTime(null);
   };
 
   const startTimer = () => {
     setIsRunning(true);
     if (secondsLeft === totalSeconds) {
       animatedValue.setValue(0);
+      setStartTime(Date.now());
     }
   };
 

--- a/app/Badges.tsx
+++ b/app/Badges.tsx
@@ -1,31 +1,77 @@
-import { GamificationContext } from '@/contexts/GamificationContext';
-import { ALL_BADGES } from '@/constants/badges';
+import { GamificationContext, EarnedBadge } from '@/contexts/GamificationContext';
+import { ALL_BADGES, BADGE_INFO, Badge } from '@/constants/badges';
 import * as NavigationBar from 'expo-navigation-bar';
-import React, { useContext, useEffect } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-export default function Badges() {
+export default function Badges({ highlightedBadge }: { highlightedBadge?: Badge | null }) {
   const { badges } = useContext(GamificationContext);
+  const [selectedBadge, setSelectedBadge] = useState<Badge | null>(null);
+  useEffect(() => {
+    if (highlightedBadge) {
+      const timer = setTimeout(() => {
+        setSelectedBadge(null);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [highlightedBadge]);
   useEffect(() => {
     NavigationBar.setButtonStyleAsync('dark');
     NavigationBar.setBackgroundColorAsync('#000');
   }, []);
 
-  return (
-    <ScrollView contentContainerStyle={styles.container}>
-      {ALL_BADGES.map((badge) => (
-        <View key={badge} style={styles.badgeWrapper}>
-          <View
-            style={[
-              styles.badge,
-              badges.includes(badge) ? styles.unlocked : styles.locked,
-            ]}
-          >
-            <Text style={styles.badgeText}>{badge}</Text>
+  const renderModal = () => {
+    if (!selectedBadge) return null;
+    const earned: EarnedBadge | undefined = badges.find((b) => b.name === selectedBadge);
+    const info = BADGE_INFO[selectedBadge];
+    return (
+      <Modal transparent animationType="fade" visible onRequestClose={() => setSelectedBadge(null)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>{selectedBadge}</Text>
+            <Text style={styles.modalDescription}>{info.description}</Text>
+            <View style={styles.checklist}>
+              {info.checklist.map((item) => (
+                <Text key={item} style={styles.checkItem}>• {item}</Text>
+              ))}
+            </View>
+            {earned ? (
+              <Text style={styles.earnedText}>Earned {new Date(earned.earnedAt).toLocaleString()}</Text>
+            ) : (
+              <Text style={styles.earnedText}>Not earned yet</Text>
+            )}
+            <TouchableOpacity style={styles.closeButton} onPress={() => setSelectedBadge(null)}>
+              <Text style={styles.closeButtonText}>Close</Text>
+            </TouchableOpacity>
           </View>
         </View>
-      ))}
-    </ScrollView>
+      </Modal>
+    );
+  };
+
+  return (
+    <>
+      <ScrollView contentContainerStyle={styles.container}>
+        {ALL_BADGES.map((badge) => {
+          const earned = badges.find((b) => b.name === badge);
+          const highlight = highlightedBadge === badge;
+          return (
+            <TouchableOpacity key={badge} style={styles.badgeWrapper} onPress={() => setSelectedBadge(badge)}>
+              <View
+                style={[
+                  styles.badge,
+                  earned ? styles.unlocked : styles.locked,
+                  highlight && styles.highlight,
+                ]}
+              >
+                <Text style={styles.badgeText}>{badge}</Text>
+              </View>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+      {renderModal()}
+    </>
   );
 }
 
@@ -47,6 +93,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#f4d2cd',
   },
+  highlight: {
+    borderWidth: 3,
+    borderColor: '#ffd54f',
+  },
   unlocked: {
     backgroundColor: '#f26b5b',
   },
@@ -58,5 +108,50 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textAlign: 'center',
     paddingHorizontal: 5,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#fdf1ef',
+    borderRadius: 20,
+    padding: 20,
+    width: '80%',
+    alignItems: 'center',
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#402050',
+    marginBottom: 10,
+  },
+  modalDescription: {
+    color: '#402050',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  checklist: {
+    alignSelf: 'flex-start',
+    marginBottom: 10,
+  },
+  checkItem: {
+    color: '#402050',
+    marginVertical: 2,
+  },
+  earnedText: {
+    color: '#402050',
+    marginBottom: 10,
+  },
+  closeButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 20,
+    backgroundColor: '#f26b5b',
+    borderRadius: 10,
+  },
+  closeButtonText: {
+    color: '#fff',
   },
 });

--- a/app/History.tsx
+++ b/app/History.tsx
@@ -1,0 +1,46 @@
+import { GamificationContext } from '@/contexts/GamificationContext';
+import * as NavigationBar from 'expo-navigation-bar';
+import React, { useContext, useEffect } from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+
+const History = () => {
+  const { sessions } = useContext(GamificationContext);
+
+  useEffect(() => {
+    NavigationBar.setButtonStyleAsync('dark');
+    NavigationBar.setBackgroundColorAsync('#000');
+  }, []);
+
+  return (
+    <FlatList
+      contentContainerStyle={styles.container}
+      data={sessions.slice().reverse()}
+      keyExtractor={(item, idx) => idx.toString()}
+      renderItem={({ item }) => (
+        <View style={styles.item}>
+          <Text style={styles.itemText}>{new Date(item.timestamp).toLocaleString()}</Text>
+          <Text style={styles.itemText}>{item.mode === 'focus' ? 'Focus' : 'Break'}</Text>
+          <Text style={styles.itemText}>{item.completed ? 'Complete' : 'Aborted'}</Text>
+        </View>
+      )}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderColor: '#e0d0cc',
+  },
+  itemText: {
+    color: '#402050',
+  },
+});
+
+export default History;

--- a/components/NotificationBanner.tsx
+++ b/components/NotificationBanner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface Props {
+  message: string;
+  onPress?: () => void;
+}
+
+const NotificationBanner = ({ message, onPress }: Props) => {
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.container} activeOpacity={0.8}>
+      <Text style={styles.text}>{message}</Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 80,
+    alignSelf: 'center',
+    backgroundColor: '#402050',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 20,
+    zIndex: 10,
+  },
+  text: {
+    color: '#fff',
+  },
+});
+
+export default NotificationBanner;

--- a/constants/badges.ts
+++ b/constants/badges.ts
@@ -7,6 +7,11 @@ export type Badge =
   | 'Rainy day focuser'
   | 'AFK';
 
+export interface BadgeInfo {
+  description: string;
+  checklist: string[];
+}
+
 export const ALL_BADGES: Badge[] = [
   'First pomodoro',
   'Hour hero',
@@ -16,3 +21,36 @@ export const ALL_BADGES: Badge[] = [
   'Rainy day focuser',
   'AFK',
 ];
+
+export const BADGE_INFO: Record<Badge, BadgeInfo> = {
+  'First pomodoro': {
+    description: 'Complete your first focus session',
+    checklist: ['Start a focus timer', 'Let it run until the end'],
+  },
+  'Hour hero': {
+    description: 'Accumulate one hour of focus time',
+    checklist: ['Finish focus sessions totalling 60 minutes'],
+  },
+  'Early bird': {
+    description: 'Finish a focus session before 10 AM',
+    checklist: ['Start and finish a focus timer before 10 AM'],
+  },
+  'Night owl': {
+    description: 'Finish a focus session after 10 PM',
+    checklist: ['Start and finish a focus timer after 10 PM'],
+  },
+  'Power hour': {
+    description: 'Focus every hour from 9 AM to 4 PM in one day',
+    checklist: [
+      'Finish at least one focus session in every hour from 9 AM to 4 PM',
+    ],
+  },
+  'Rainy day focuser': {
+    description: 'Focus while it is raining',
+    checklist: ['Complete a focus session when the weather is rainy'],
+  },
+  AFK: {
+    description: 'Take a break for 15 minutes or more',
+    checklist: ['Start a break session of at least 15 minutes'],
+  },
+};


### PR DESCRIPTION
## Summary
- expand badge definitions with descriptions and checklists
- record session history and badge timestamps in gamification context
- add in-app notification banner and badge highlight
- show detailed badge info in a modal
- log timer history and include new History screen
- keep status and navigation bars dark

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_6856fcdc2ee48320b443bffbb30db021