### PR TITLE
Add objective system replacing break mode

### DIFF
--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -1,14 +1,14 @@
 import { useNotification } from '@/components/NotificationManager';
+import { OBJECTIVES } from '@/constants/objectives';
 import { GamificationContext } from '@/contexts/GamificationContext';
 import { Ionicons } from '@expo/vector-icons';
 import { Audio } from 'expo-av';
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import * as NavigationBar from 'expo-navigation-bar';
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Animated, Easing, Modal, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+import { Animated, Easing, Modal, ScrollView, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import Fireworks from './Fireworks';
-import { OBJECTIVES } from '@/constants/objectives';
 
 const TIMER_INTERVALS = [5, 10, 15, 20, 25, 30, 45];
 const DEFAULT_MINUTES = 15;
@@ -404,27 +404,27 @@ const CircularTimer = () => {
         <View style={styles.modalOverlay}>
           <View style={styles.modalContent}>
             <Text style={styles.modalTitle}>Select Objective</Text>
-            <View style={styles.modeButtons}>
+            <ScrollView style={{maxHeight: 300, width: '100%'}} contentContainerStyle={styles.objectiveGrid}>
               {OBJECTIVES.map(obj => (
                 <TouchableOpacity
                   key={obj.name}
                   style={[
-                    styles.modeButton,
-                    objective === obj.name && styles.selectedModeButton
+                    styles.objectiveButton,
+                    objective === obj.name && styles.selectedObjectiveButton
                   ]}
                   onPress={() => handleObjectiveSelect(obj.name)}
                 >
                   <Text
                     style={[
-                      styles.modeButtonText,
-                      objective === obj.name && styles.selectedModeButtonText
+                      styles.objectiveButtonText,
+                      objective === obj.name && styles.selectedObjectiveButtonText
                     ]}
                   >
                     {obj.emoji} {obj.name}
                   </Text>
                 </TouchableOpacity>
               ))}
-            </View>
+            </ScrollView>
             <TouchableOpacity 
               style={styles.closeButton}
               onPress={handleCancel}
@@ -845,6 +845,32 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#402050',
     marginBottom: 10,
+  },
+  objectiveGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginTop: 10,
+  },
+  objectiveButton: {
+    margin: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 20,
+    backgroundColor: '#f4d2cd',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  selectedObjectiveButton: {
+    backgroundColor: '#f26b5b',
+  },
+  objectiveButtonText: {
+    fontSize: 16,
+    color: '#402050',
+    fontWeight: '600',
+  },
+  selectedObjectiveButtonText: {
+    color: '#fff',
   },
 });
 

--- a/app/(main)/components/CircularTimer.tsx
+++ b/app/(main)/components/CircularTimer.tsx
@@ -8,12 +8,12 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { Animated, Easing, Modal, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import Fireworks from './Fireworks';
+import { OBJECTIVES } from '@/constants/objectives';
 
 const TIMER_INTERVALS = [5, 10, 15, 20, 25, 30, 45];
 const DEFAULT_MINUTES = 15;
 const TOTAL_SECONDS = DEFAULT_MINUTES * 60;
 const DEFAULT_BACKGROUND = '#fdf1ef';
-const BREAK_BACKGROUND = '#fdf1ef';
 
 const CircularTimer = () => {
   const { width, height } = useWindowDimensions();
@@ -22,7 +22,7 @@ const CircularTimer = () => {
   const timerSize = isTablet ? 300 : 250;
   const [secondsLeft, setSecondsLeft] = useState(TOTAL_SECONDS);
   const [totalSeconds, setTotalSeconds] = useState(TOTAL_SECONDS);
-  const [mode, setMode] = useState<'focus' | 'break'>('focus');
+  const [objective, setObjective] = useState('Focus');
   const [isEditing, setIsEditing] = useState(false);
   const [isEditingDuration, setIsEditingDuration] = useState(false);
   const [tempTitle, setTempTitle] = useState('Focus');
@@ -43,7 +43,7 @@ const CircularTimer = () => {
     startTimer: startContextTimer,
     stopTimer: stopContextTimer,
     resumeTimer: resumeContextTimer,
-    setDisplayMode
+    setDisplayObjective
   } = useContext(GamificationContext);
   const rewardGiven = useRef(false);
   const { showNotification } = useNotification();
@@ -75,7 +75,7 @@ const CircularTimer = () => {
   useEffect(() => {
     if (secondsLeft === 0) {
       if (!rewardGiven.current) {
-        completeSession(mode, totalSeconds);
+        completeSession(objective, totalSeconds);
         rewardGiven.current = true;
       }
       setShowCelebration(true);
@@ -106,7 +106,7 @@ const CircularTimer = () => {
       setShowCelebration(false);
       gradientAnim.stopAnimation();
     }
-  }, [secondsLeft, mode, totalSeconds, completeSession]);
+  }, [secondsLeft, objective, totalSeconds, completeSession]);
 
   const strokeDashoffset = animatedValue.interpolate({
     inputRange: [0, 1],
@@ -140,12 +140,12 @@ const CircularTimer = () => {
   const resetTimer = () => {
     setSecondsLeft(totalSeconds);
     stopContextTimer();
-    setBackgroundColor(mode === 'focus' ? DEFAULT_BACKGROUND : BREAK_BACKGROUND);
+    setBackgroundColor(DEFAULT_BACKGROUND);
     animatedValue.setValue(0);
   };
 
   const startTimer = () => {
-    startContextTimer(mode, totalSeconds);
+    startContextTimer(objective, totalSeconds);
     if (secondsLeft === totalSeconds) {
       animatedValue.setValue(0);
     }
@@ -164,11 +164,11 @@ const CircularTimer = () => {
       pauseTimer();
     }
     setIsEditing(true);
-    setTempTitle(mode === 'focus' ? 'Focus' : 'Break');
+    setTempTitle(objective);
   };
 
   const handleCancel = () => {
-    setTempTitle(mode === 'focus' ? 'Focus' : 'Break');
+    setTempTitle(objective);
     setIsEditing(false);
     if (wasRunningBeforeEdit) {
       startTimer();
@@ -181,7 +181,7 @@ const CircularTimer = () => {
     setSecondsLeft(newTotalSeconds);
     setIsEditingDuration(false);
     stopContextTimer();
-    setBackgroundColor(mode === 'focus' ? DEFAULT_BACKGROUND : BREAK_BACKGROUND);
+    setBackgroundColor(DEFAULT_BACKGROUND);
     animatedValue.setValue(0);
     setShowCustomInput(false);
     setCustomMinutes('');
@@ -194,10 +194,10 @@ const CircularTimer = () => {
     }
   };
 
-  const handleModeSelect = (selectedMode: 'focus' | 'break') => {
-    setMode(selectedMode);
+  const handleObjectiveSelect = (selected: string) => {
+    setObjective(selected);
     setIsEditing(false);
-    // Reset timer when mode changes
+    // Reset timer when objective changes
     setSecondsLeft(totalSeconds);
     stopContextTimer();
     animatedValue.setValue(0);
@@ -247,15 +247,15 @@ const CircularTimer = () => {
     playAlarm();
   }, [secondsLeft, alarmSound, sound]);
 
-  // Update background color when mode changes
+  // Update background color when objective changes
   useEffect(() => {
-    setBackgroundColor(mode === 'focus' ? DEFAULT_BACKGROUND : BREAK_BACKGROUND);
-  }, [mode]);
+    setBackgroundColor(DEFAULT_BACKGROUND);
+  }, [objective]);
 
-  // Update display mode when local mode changes
+  // Update display objective when local objective changes
   useEffect(() => {
-    setDisplayMode(mode);
-  }, [mode, setDisplayMode]);
+    setDisplayObjective(objective);
+  }, [objective, setDisplayObjective]);
 
   return (
     <View style={[styles.container, { backgroundColor, width: '100%', height: '100%' }]}>
@@ -263,7 +263,7 @@ const CircularTimer = () => {
       <View style={[styles.mainContent, isLandscape && styles.mainContentLandscape]}>
         <View style={styles.leftSection}>
           <View style={[styles.titleContainer, isLandscape && styles.titleContainerLandscape]}>
-            <Text style={styles.title}>{mode === 'focus' ? 'Focus' : 'Break'}</Text>
+            <Text style={styles.title}>{OBJECTIVES.find(o => o.name === objective)?.emoji || '🎯'} {objective}</Text>
             {
               !isTimerRunning && (
                 <TouchableOpacity onPress={handleEdit} style={styles.iconButton}>
@@ -403,36 +403,27 @@ const CircularTimer = () => {
       >
         <View style={styles.modalOverlay}>
           <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>Select Mode</Text>
+            <Text style={styles.modalTitle}>Select Objective</Text>
             <View style={styles.modeButtons}>
-              <TouchableOpacity
-                style={[
-                  styles.modeButton,
-                  mode === 'focus' && styles.selectedModeButton
-                ]}
-                onPress={() => handleModeSelect('focus')}
-              >
-                <Text style={[
-                  styles.modeButtonText,
-                  mode === 'focus' && styles.selectedModeButtonText
-                ]}>
-                  Focus
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[
-                  styles.modeButton,
-                  mode === 'break' && styles.selectedModeButton
-                ]}
-                onPress={() => handleModeSelect('break')}
-              >
-                <Text style={[
-                  styles.modeButtonText,
-                  mode === 'break' && styles.selectedModeButtonText
-                ]}>
-                  Break
-                </Text>
-              </TouchableOpacity>
+              {OBJECTIVES.map(obj => (
+                <TouchableOpacity
+                  key={obj.name}
+                  style={[
+                    styles.modeButton,
+                    objective === obj.name && styles.selectedModeButton
+                  ]}
+                  onPress={() => handleObjectiveSelect(obj.name)}
+                >
+                  <Text
+                    style={[
+                      styles.modeButtonText,
+                      objective === obj.name && styles.selectedModeButtonText
+                    ]}
+                  >
+                    {obj.emoji} {obj.name}
+                  </Text>
+                </TouchableOpacity>
+              ))}
             </View>
             <TouchableOpacity 
               style={styles.closeButton}

--- a/app/History.tsx
+++ b/app/History.tsx
@@ -1,6 +1,7 @@
 import { GamificationContext } from '@/contexts/GamificationContext';
 import { Ionicons } from '@expo/vector-icons';
 import * as NavigationBar from 'expo-navigation-bar';
+import { OBJECTIVES } from '@/constants/objectives';
 import React, { useContext, useEffect } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
@@ -29,13 +30,7 @@ export default function History() {
     });
   };
 
-  const getModeIcon = (mode: 'focus' | 'break') => {
-    return mode === 'focus' ? 'timer' : 'cafe';
-  };
-
-  const getModeColor = (mode: 'focus' | 'break') => {
-    return mode === 'focus' ? '#f26b5b' : '#4CAF50';
-  };
+  const getEmoji = (name: string) => OBJECTIVES.find(o => o.name === name)?.emoji || '🎯';
 
   if (sessions.length === 0) {
     return (
@@ -46,7 +41,7 @@ export default function History() {
           Your Pomodoro session logs will appear here
         </Text>
         <Text style={styles.emptySubtext}>
-          Complete focus and break sessions to see your activity history
+          Complete sessions to see your activity history
         </Text>
       </View>
     );
@@ -64,24 +59,8 @@ export default function History() {
       <View style={styles.summaryContainer}>
         <View style={styles.summaryRow}>
           <View style={styles.summaryItem}>
-            <Text style={styles.summaryLabel}>Focus Sessions</Text>
-            <Text style={styles.summaryValue}>
-              {sessions.filter(s => s.mode === 'focus').length}
-            </Text>
-          </View>
-          <View style={styles.summaryItem}>
-            <Text style={styles.summaryLabel}>Break Sessions</Text>
-            <Text style={styles.summaryValue}>
-              {sessions.filter(s => s.mode === 'break').length}
-            </Text>
-          </View>
-        </View>
-        <View style={styles.summaryRow}>
-          <View style={styles.summaryItem}>
             <Text style={styles.summaryLabel}>Total Sessions</Text>
-            <Text style={styles.summaryValue}>
-              {sessions.length}
-            </Text>
+            <Text style={styles.summaryValue}>{sessions.length}</Text>
           </View>
           <View style={styles.summaryItem}>
             <Text style={styles.summaryLabel}>Total Time</Text>
@@ -111,13 +90,8 @@ export default function History() {
           <View key={index} style={styles.tableRow}>
             <View style={styles.cell}>
               <View style={styles.modeContainer}>
-                <Ionicons 
-                  name={getModeIcon(session.mode)} 
-                  size={16} 
-                  color={getModeColor(session.mode)} 
-                />
-                <Text style={[styles.modeText, { color: getModeColor(session.mode) }]}>
-                  {session.mode === 'focus' ? 'Focus' : 'Break'}
+                <Text style={styles.modeText}>
+                  {getEmoji(session.objective)} {session.objective}
                 </Text>
               </View>
             </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ErrorSuppressor from '@/components/ErrorSuppressor';
 import { NotificationProvider } from '@/components/NotificationManager';
 import { GamificationContext, GamificationProvider } from '@/contexts/GamificationContext';
+import { OBJECTIVES } from '@/constants/objectives';
 
 import Main from './(main)/index';
 import Badges from './Badges';
@@ -116,8 +117,10 @@ export default function RootLayout() {
   );
 }
 
+const getEmoji = (name: string) => OBJECTIVES.find(o => o.name === name)?.emoji || '🎯';
+
 const Header = () => {
-  const { coins, level, isTimerRunning, displayMode, remainingTime } = useContext(GamificationContext);
+  const { coins, level, isTimerRunning, displayObjective, remainingTime } = useContext(GamificationContext);
 
   const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
@@ -130,13 +133,8 @@ const Header = () => {
       {isTimerRunning && remainingTime !== null ? (
         <View style={styles.timerHeader}>
           <View style={styles.timerInfo}>
-            <Ionicons 
-              name={displayMode === 'focus' ? 'timer' : 'cafe'} 
-              size={16} 
-              color={displayMode === 'focus' ? '#f26b5b' : '#4CAF50'} 
-            />
             <Text style={styles.timerText}>
-              {displayMode === 'focus' ? 'Focus' : 'Break'} • {formatTime(remainingTime)}
+              {getEmoji(displayObjective || 'Focus')} {displayObjective || 'Focus'} • {formatTime(remainingTime)}
             </Text>
           </View>
           <Text style={styles.statsText}>Lvl {level} • {coins} coins</Text>

--- a/constants/objectives.ts
+++ b/constants/objectives.ts
@@ -1,0 +1,14 @@
+export interface Objective {
+  name: string;
+  emoji: string;
+}
+
+export const OBJECTIVES: Objective[] = [
+  { name: 'Focus', emoji: '🎯' },
+  { name: 'Deep work', emoji: '🧠' },
+  { name: 'Read', emoji: '📚' },
+  { name: 'Do homework', emoji: '📝' },
+  { name: 'Test prep', emoji: '🧪' },
+  { name: 'Workout', emoji: '🏋️' },
+  { name: 'Meditation', emoji: '🧘' }
+];

--- a/contexts/GamificationContext.tsx
+++ b/contexts/GamificationContext.tsx
@@ -5,7 +5,7 @@ import React, { createContext, useCallback, useEffect, useRef, useState } from '
 
 interface SessionEntry {
   timestamp: number;
-  mode: 'focus' | 'break';
+  objective: string;
   duration: number;
 }
 
@@ -17,21 +17,21 @@ interface GamificationState {
   totalFocusTime: number;
   sessions: SessionEntry[];
   isTimerRunning: boolean;
-  currentSessionMode: 'focus' | 'break' | null;
+  currentObjective: string | null;
   currentSessionStartTime: number | null;
   currentSessionDuration: number | null;
   remainingTime: number | null;
-  displayMode: 'focus' | 'break' | null;
+  displayObjective: string | null;
 }
 
 interface GamificationContextType extends GamificationState {
-  completeSession: (mode: 'focus' | 'break', duration: number) => void;
+  completeSession: (objective: string, duration: number) => void;
   resetProgress: () => void;
-  startTimer: (mode: 'focus' | 'break', duration: number) => void;
+  startTimer: (objective: string, duration: number) => void;
   stopTimer: () => void;
   resumeTimer: () => void;
   getRemainingTime: () => number | null;
-  setDisplayMode: (mode: 'focus' | 'break' | null) => void;
+  setDisplayObjective: (objective: string | null) => void;
 }
 
 const defaultState: GamificationState = {
@@ -42,11 +42,11 @@ const defaultState: GamificationState = {
   totalFocusTime: 0,
   sessions: [],
   isTimerRunning: false,
-  currentSessionMode: null,
+  currentObjective: null,
   currentSessionStartTime: null,
   currentSessionDuration: null,
   remainingTime: null,
-  displayMode: null,
+  displayObjective: null,
 };
 
 export const GamificationContext = createContext<GamificationContextType>({
@@ -57,7 +57,7 @@ export const GamificationContext = createContext<GamificationContextType>({
   stopTimer: () => {},
   resumeTimer: () => {},
   getRemainingTime: () => null,
-  setDisplayMode: () => {},
+  setDisplayObjective: () => {},
 });
 
 const STORAGE_KEY = 'gamificationState';
@@ -83,7 +83,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
         
         if (remaining <= 0) {
           // Timer completed
-          completeSession(state.currentSessionMode!, state.currentSessionDuration!);
+          completeSession(state.currentObjective!, state.currentSessionDuration!);
         } else {
           // Update remaining time
           setState(prev => ({
@@ -107,7 +107,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       }
       // Do NOT clear remainingTime here so the timer can be resumed
     }
-  }, [state.isTimerRunning, state.currentSessionStartTime, state.currentSessionDuration, state.currentSessionMode]);
+  }, [state.isTimerRunning, state.currentSessionStartTime, state.currentSessionDuration, state.currentObjective]);
 
   useEffect(() => {
     (async () => {
@@ -119,7 +119,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
           setState({
             ...parsedData,
             isTimerRunning: false,
-            currentSessionMode: null,
+            currentObjective: null,
             currentSessionStartTime: null,
             currentSessionDuration: null,
             remainingTime: null,
@@ -137,11 +137,11 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     );
   }, [state]);
 
-  const startTimer = useCallback((mode: 'focus' | 'break', duration: number) => {
+  const startTimer = useCallback((objective: string, duration: number) => {
     setState(prev => ({
       ...prev,
       isTimerRunning: true,
-      currentSessionMode: mode,
+      currentObjective: objective,
       currentSessionStartTime: Date.now(),
       currentSessionDuration: duration,
       remainingTime: duration,
@@ -167,7 +167,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       ...prev,
       isTimerRunning: false,
       currentSessionStartTime: null,
-      // Don't clear currentSessionMode, currentSessionDuration, or remainingTime
+      // Don't clear currentObjective, currentSessionDuration, or remainingTime
       // so the timer can be resumed
     }));
   }, []);
@@ -176,7 +176,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     return state.remainingTime;
   }, [state.remainingTime]);
 
-  const completeSession = useCallback(async (mode: 'focus' | 'break', duration: number) => {
+  const completeSession = useCallback(async (objective: string, duration: number) => {
     // Stop timer first
     if (timerInterval.current) {
       clearInterval(timerInterval.current);
@@ -184,15 +184,13 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     }
 
     const now = new Date();
-    const sessions = [...state.sessions, { timestamp: now.getTime(), mode, duration }];
+    const sessions = [...state.sessions, { timestamp: now.getTime(), objective, duration }];
 
     let { coins, completedPomodoros, totalFocusTime, badges } = state;
 
-    if (mode === 'focus') {
-      completedPomodoros += 1;
-      totalFocusTime += duration;
-      coins += 10; // 10 coins per focus session
-    }
+    completedPomodoros += 1;
+    totalFocusTime += duration;
+    coins += 10; // 10 coins per session
 
     // Track new badges earned
     const newBadges: Badge[] = [];
@@ -209,27 +207,19 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
     }
 
     const hour = now.getHours();
-    if (mode === 'focus' && hour < 10 && !badges.includes('Early bird')) {
+    if (hour < 10 && !badges.includes('Early bird')) {
       badges = [...badges, 'Early bird'];
       newBadges.push('Early bird');
     }
 
-    if (mode === 'focus' && hour >= 22 && !badges.includes('Night owl')) {
+    if (hour >= 22 && !badges.includes('Night owl')) {
       badges = [...badges, 'Night owl'];
       newBadges.push('Night owl');
     }
 
-    if (mode === 'break' && duration >= 900 && !badges.includes('AFK')) {
-      badges = [...badges, 'AFK'];
-      newBadges.push('AFK');
-    }
-
     if (!badges.includes('Power hour')) {
       const todayHours = sessions
-        .filter(
-          (s) =>
-            s.mode === 'focus' && new Date(s.timestamp).toDateString() === now.toDateString()
-        )
+        .filter((s) => new Date(s.timestamp).toDateString() === now.toDateString())
         .map((s) => new Date(s.timestamp).getHours());
       const required = [9, 10, 11, 12, 13, 14, 15, 16];
       if (required.every((h) => todayHours.includes(h))) {
@@ -238,7 +228,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       }
     }
 
-    if (mode === 'focus' && !badges.includes('Rainy day focuser')) {
+    if (!badges.includes('Rainy day focuser')) {
       try {
         if (await isRainy()) {
           badges = [...badges, 'Rainy day focuser'];
@@ -259,21 +249,20 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       totalFocusTime,
       sessions,
       isTimerRunning: false,
-      currentSessionMode: null,
+      currentObjective: null,
       currentSessionStartTime: null,
       currentSessionDuration: null,
       remainingTime: null,
-      displayMode: state.displayMode, // Preserve display mode
+      displayObjective: state.displayObjective, // Preserve display objective
     };
 
     setState(newState);
 
     // Show notifications
-    const sessionType = mode === 'focus' ? 'Focus' : 'Break';
     const durationMinutes = Math.floor(duration / 60);
     showNotification(
-      `${sessionType} Great job!`,
-      `You completed a ${durationMinutes}-minute ${sessionType.toLowerCase()} session.`
+      `${objective} - Great job!`,
+      `You completed a ${durationMinutes}-minute ${objective.toLowerCase()} session.`
     );
 
     // Show badge notifications
@@ -284,19 +273,19 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
         'success'
       );
     });
-  }, [state.sessions, state.coins, state.completedPomodoros, state.totalFocusTime, state.badges, state.displayMode, showNotification]);
+  }, [state.sessions, state.coins, state.completedPomodoros, state.totalFocusTime, state.badges, state.displayObjective, showNotification]);
 
   const resetProgress = useCallback(() => {
     setState({
       ...defaultState,
-      displayMode: state.displayMode, // Preserve display mode
+      displayObjective: state.displayObjective, // Preserve display objective
     });
-  }, [state.displayMode]);
+  }, [state.displayObjective]);
 
-  const setDisplayMode = useCallback((mode: 'focus' | 'break' | null) => {
+  const setDisplayObjective = useCallback((objective: string | null) => {
     setState(prev => ({
       ...prev,
-      displayMode: mode,
+      displayObjective: objective,
     }));
   }, []);
 
@@ -309,7 +298,7 @@ export const GamificationProvider = ({ children }: { children: React.ReactNode }
       stopTimer,
       resumeTimer,
       getRemainingTime,
-      setDisplayMode
+      setDisplayObjective
     }}>
       {children}
     </GamificationContext.Provider>


### PR DESCRIPTION
## Summary
- replace break mode with multiple objectives
- track objective name and emoji in gamification context
- list and select objectives from timer screen
- show objective emoji in header and log entries

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_68571daca5048320a0cff12159d7e80c