### PR TITLE
Replace break mode with objectives

### DIFF
--- a/app/Badges.tsx
+++ b/app/Badges.tsx
@@ -65,8 +65,6 @@ export default function Badges() {
         return 'flash';
       case 'Rainy day focuser':
         return 'rainy';
-      case 'AFK':
-        return 'cafe';
       default:
         return 'trophy';
     }
@@ -90,8 +88,6 @@ export default function Badges() {
         return '#FFD93D';
       case 'Rainy day focuser':
         return '#87CEEB';
-      case 'AFK':
-        return '#8B4513';
       default:
         return '#f26b5b';
     }
@@ -111,8 +107,6 @@ export default function Badges() {
         return 'Complete focus sessions in 8 consecutive hours';
       case 'Rainy day focuser':
         return 'Focus during rainy weather';
-      case 'AFK':
-        return 'Take a break longer than 15 minutes';
       default:
         return 'Achievement unlocked!';
     }
@@ -132,8 +126,6 @@ export default function Badges() {
         return 'Achieve the ultimate productivity feat by completing focus sessions across 8 consecutive hours (9 AM to 5 PM). This represents a full workday of focused effort.';
       case 'Rainy day focuser':
         return 'Maintain your focus even when the weather tries to distract you. This badge celebrates your ability to stay productive regardless of external conditions.';
-      case 'AFK':
-        return 'Take proper breaks by stepping away for more than 15 minutes. This badge encourages healthy work-life balance and prevents burnout.';
       default:
         return 'An achievement that showcases your dedication to productivity and focus.';
     }

--- a/app/History.tsx
+++ b/app/History.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as NavigationBar from 'expo-navigation-bar';
 import React, { useContext, useEffect } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { OBJECTIVES } from '@/constants/objectives';
 
 export default function History() {
   const { sessions } = useContext(GamificationContext);
@@ -29,13 +30,8 @@ export default function History() {
     });
   };
 
-  const getModeIcon = (mode: 'focus' | 'break') => {
-    return mode === 'focus' ? 'timer' : 'cafe';
-  };
 
-  const getModeColor = (mode: 'focus' | 'break') => {
-    return mode === 'focus' ? '#f26b5b' : '#4CAF50';
-  };
+  const emojiMap = Object.fromEntries(OBJECTIVES.map(o => [o.name, o.emoji]));
 
   if (sessions.length === 0) {
     return (
@@ -46,7 +42,7 @@ export default function History() {
           Your Pomodoro session logs will appear here
         </Text>
         <Text style={styles.emptySubtext}>
-          Complete focus and break sessions to see your activity history
+          Complete sessions to see your activity history
         </Text>
       </View>
     );
@@ -66,23 +62,15 @@ export default function History() {
           <View style={styles.summaryItem}>
             <Text style={styles.summaryLabel}>Focus Sessions</Text>
             <Text style={styles.summaryValue}>
-              {sessions.filter(s => s.mode === 'focus').length}
+              {sessions.filter(s => s.objective === 'Focus').length}
             </Text>
           </View>
           <View style={styles.summaryItem}>
-            <Text style={styles.summaryLabel}>Break Sessions</Text>
-            <Text style={styles.summaryValue}>
-              {sessions.filter(s => s.mode === 'break').length}
-            </Text>
+            <Text style={styles.summaryLabel}>Total Sessions</Text>
+            <Text style={styles.summaryValue}>{sessions.length}</Text>
           </View>
         </View>
         <View style={styles.summaryRow}>
-          <View style={styles.summaryItem}>
-            <Text style={styles.summaryLabel}>Total Sessions</Text>
-            <Text style={styles.summaryValue}>
-              {sessions.length}
-            </Text>
-          </View>
           <View style={styles.summaryItem}>
             <Text style={styles.summaryLabel}>Total Time</Text>
             <Text style={styles.summaryValue}>
@@ -111,14 +99,7 @@ export default function History() {
           <View key={index} style={styles.tableRow}>
             <View style={styles.cell}>
               <View style={styles.modeContainer}>
-                <Ionicons 
-                  name={getModeIcon(session.mode)} 
-                  size={16} 
-                  color={getModeColor(session.mode)} 
-                />
-                <Text style={[styles.modeText, { color: getModeColor(session.mode) }]}>
-                  {session.mode === 'focus' ? 'Focus' : 'Break'}
-                </Text>
+                <Text style={styles.modeText}>{emojiMap[session.objective]} {session.objective}</Text>
               </View>
             </View>
             

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -117,7 +117,7 @@ export default function RootLayout() {
 }
 
 const Header = () => {
-  const { coins, level, isTimerRunning, displayMode, remainingTime } = useContext(GamificationContext);
+  const { coins, level, isTimerRunning, displayObjective, remainingTime } = useContext(GamificationContext);
 
   const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
@@ -130,13 +130,8 @@ const Header = () => {
       {isTimerRunning && remainingTime !== null ? (
         <View style={styles.timerHeader}>
           <View style={styles.timerInfo}>
-            <Ionicons 
-              name={displayMode === 'focus' ? 'timer' : 'cafe'} 
-              size={16} 
-              color={displayMode === 'focus' ? '#f26b5b' : '#4CAF50'} 
-            />
             <Text style={styles.timerText}>
-              {displayMode === 'focus' ? 'Focus' : 'Break'} • {formatTime(remainingTime)}
+              {displayObjective} • {formatTime(remainingTime)}
             </Text>
           </View>
           <Text style={styles.statsText}>Lvl {level} • {coins} coins</Text>

--- a/constants/badges.ts
+++ b/constants/badges.ts
@@ -4,8 +4,7 @@ export type Badge =
   | 'Early bird'
   | 'Night owl'
   | 'Power hour'
-  | 'Rainy day focuser'
-  | 'AFK';
+  | 'Rainy day focuser';
 
 export const ALL_BADGES: Badge[] = [
   'First pomodoro',
@@ -14,5 +13,4 @@ export const ALL_BADGES: Badge[] = [
   'Night owl',
   'Power hour',
   'Rainy day focuser',
-  'AFK',
 ];

--- a/constants/objectives.ts
+++ b/constants/objectives.ts
@@ -1,0 +1,20 @@
+export type Objective =
+  | 'Focus'
+  | 'Deep work'
+  | 'Read'
+  | 'Do homework'
+  | 'Test prep'
+  | 'Workout'
+  | 'Meditation';
+
+export const OBJECTIVES: { name: Objective; emoji: string }[] = [
+  { name: 'Focus', emoji: '🎯' },
+  { name: 'Deep work', emoji: '🧠' },
+  { name: 'Read', emoji: '📖' },
+  { name: 'Do homework', emoji: '📚' },
+  { name: 'Test prep', emoji: '📝' },
+  { name: 'Workout', emoji: '🏋️' },
+  { name: 'Meditation', emoji: '🧘' },
+];
+
+export const DEFAULT_OBJECTIVE: Objective = 'Focus';


### PR DESCRIPTION
## Summary
- remove break mode references
- track sessions by objective
- show objectives with emoji selection in timer
- log objectives in history screen
- display current objective in header
- drop AFK badge

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_68571daca5048320a0cff12159d7e80c